### PR TITLE
Fix dotfiles for Apple Silicon + remove stale configs

### DIFF
--- a/bash/.alias
+++ b/bash/.alias
@@ -112,13 +112,12 @@ alias kpr='kubectl get pods --field-selector status.phase=Running'
 
 # Misc
 
-alias slack="cd ~/repos/sclack/ && s. && ./app.py"
 alias ge="great_expectations"
 alias marked='open -a "Marked 2"'
 alias cat='bat'
 
 # Pulumi
-alias p'pulumi'
+alias p='pulumi'
 alias pp='pulumi preview'
 alias pd='pulumi destroy'
 alias pup='pulumi up'
@@ -151,20 +150,3 @@ else
    # assume something else
 fi
 
-# Travis debug job
-travis-debug-job () {
-  if [ -n "${TRAVIS_ORG_TOKEN}" ] ; then
-  else
-    echo 'Please set your environment variable TRAVIS_ORG_TOKEN. Find this in your travis settings.'
-    return 1
-  fi
-  if [[ $# -eq 0 ]] ; then
-    echo 'Please enter travis job number.'
-    return 1
-  fi
-  echo About to start a debugging job for job "$1"
-
-  curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Travis-API-Version: 3" -H "Authorization: token $TRAVIS_ORG_TOKEN" -d '{ "quiet": true }' https://api.travis-ci.org/job/$1/debug
-
-  open "https://travis-ci.org/great-expectations/great_expectations/jobs/$1"
-}

--- a/bash/.exports
+++ b/bash/.exports
@@ -1,16 +1,20 @@
 # Non secret exports
 
-# Python 3.13
-export PATH="/usr/local/Cellar/python@3.13/3.13.4/bin:${PATH}"
+# Homebrew prefix (works on both Apple Silicon and Intel)
+if [ -d /opt/homebrew ]; then
+  BREW_PREFIX="/opt/homebrew"
+else
+  BREW_PREFIX="/usr/local"
+fi
+
+# Python (Homebrew)
+export PATH="$BREW_PREFIX/opt/python/libexec/bin:${PATH}"
 
 # Local bin dir in home directory
-export PATH="/Users/taylor/bin:$PATH"
+export PATH="$HOME/bin:$PATH"
 
-# use the ruby installed with Brew
-export PATH="/usr/local/opt/ruby/bin:$PATH"
-
-# Google Cloud CLI
-export PATH="/Users/taylor/bin/google-cloud-sdk/bin:$PATH"
+# Ruby (Homebrew)
+[ -d "$BREW_PREFIX/opt/ruby/bin" ] && export PATH="$BREW_PREFIX/opt/ruby/bin:$PATH"
 
 # fzf default arguments
 FZF_DEFAULT_OPTS='-m'  # default to multi select mode

--- a/bash/.exports
+++ b/bash/.exports
@@ -20,36 +20,5 @@ export PATH="$HOME/bin:$PATH"
 FZF_DEFAULT_OPTS='-m'  # default to multi select mode
 
 # Disable multithreading security that can sometimes bork python processes
-# https://stackoverflow.com/questions/50168647/munegsignal.sigabortltiprocessing-causes-python-to-crash-and-gives-an-error-may-have-been-in-progr/52230415#52230415
+# https://stackoverflow.com/questions/50168647/multiprocessing-causes-python-to-crash
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-
-# brew python@3.7
-# export PATH="/usr/local/opt/python@3.7/bin:$PATH"
-# ln -s /usr/local/opt/python@3.7/bin/python3 /usr/local/opt/python@3.7/bin/python
-# ln -s /usr/local/opt/python@3.7/bin/pip3 /usr/local/opt/python@3.7/bin/pip
-
-# For compilers to find python@3.7 you may need to set:
-# export LDFLAGS="-L/usr/local/opt/python@3.7/lib"
-# For pkg-config to find python@3.7 you may need to set:
-# export PKG_CONFIG_PATH="/usr/local/opt/python@3.7/lib/pkgconfig"
-
-
-# Python 3.11 installed with Brew
-# export PATH="/usr/local/opt/python@3.11/libexec/bin:$PATH"
-
-# Python 3.9
-# export PATH="/usr/local/opt/python@3.9/bin:$PATH"
-# [ -e "/usr/local/opt/python@3.9/bin/python" ] || ln -s /usr/local/opt/python@3.9/bin/python3 /usr/local/opt/python@3.9/bin/python
-# [ -e "/usr/local/opt/python@3.9/bin/pip" ] || ln -s /usr/local/opt/python@3.9/bin/pip3 /usr/local/opt/python@3.9/bin/pip
-# For compilers to find python@3.9 you may need to set:
-# export LDFLAGS="-L/usr/local/opt/python@3.9/lib"
-# For pkg-config to find python@3.9 you may need to set:
-# export PKG_CONFIG_PATH="/usr/local/opt/python@3.9/lib/pkgconfig"
-
-# All the spark stuff
-# export JAVA_HOME=`/usr/libexec/java_home -v 1.8.0_212`
-# export SPARK_HOME='/Users/taylor/Library/Local/SoftwareDevelopment/spark-3.1.2-bin-hadoop3.2'
-# export PATH="${PATH}:${SPARK_HOME}/bin"
-# export SPARK_LOCAL_IP="127.0.0.1"
-# export SCALA_HOME='/Users/taylor/Library/Local/SoftwareDevelopment/scala3-3.0.0'
-# export PATH="${PATH}:${SCALA_HOME}/bin"

--- a/bash/.gitconfig
+++ b/bash/.gitconfig
@@ -38,7 +38,7 @@
 	email = Aylr@users.noreply.github.com
 [credential "https://github.com"]
 	helper = 
-	helper = !/usr/local/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
 	helper = 
-	helper = !/usr/local/bin/gh auth git-credential
+	helper = !gh auth git-credential

--- a/brew.sh
+++ b/brew.sh
@@ -5,7 +5,9 @@ brew upgrade
 
 # Python
 brew install python
-brew install python-tk                     # useful if anything is using tk such as pandas_profiling
+brew install python-tk                     # useful if anything is using tk such as eandas_profiling
+brew install uv
+
 
 # Install a modern version of Bash.
 brew install bash
@@ -42,12 +44,11 @@ brew install jq
 
 # fuzzy command line finder https://github.com/junegunn/fzf#usage
 brew install fzf
-$(brew --prefix)/opt/fzf/install
+# NOTE: fzf shell integration is run in setup.sh Stage 5
 
 # Dev tools
 brew install tmux
 brew install supabase/tap/supabase
-brew install tailscale
 brew install --cask iterm2
 brew install --cask tailscale
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,130 +1,29 @@
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
-# Initialization code that may require console input (password prompts, [y/n]
-# confirmations, etc.) must go above this block, everything else may go below.
 if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
-# If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:$PATH
-
-# Path to your oh-my-zsh installation.
-export ZSH="/Users/taylor/.oh-my-zsh"
-
-# Set name of the theme to load --- if set to "random", it will
-# load a random theme each time oh-my-zsh is loaded, in which case,
-# to know which specific one was loaded, run: echo $RANDOM_THEME
-# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-# ZSH_THEME="af-magic"
-# ZSH_THEME="avit"
-# ZSH_THEME="cloud"
-# ZSH_THEME="terminalparty"
-# ZSH_THEME="random"
+# ── Oh My Zsh ────────────────────────────────────────────────────────────────
+export ZSH="$HOME/.oh-my-zsh"
 ZSH_THEME=powerlevel10k/powerlevel10k
-
-# Set list of themes to pick from when loading at random
-# Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in ~/.oh-my-zsh/themes/
-# If set to an empty array, this variable will have no effect.
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" "af-magic" "avit" "cloud" "terminalparty" "theunraveler")
-
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion.
-# Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment the following line to disable bi-weekly auto-update checks.
-# DISABLE_AUTO_UPDATE="true"
-
-# Uncomment the following line to automatically update without prompting.
-# DISABLE_UPDATE_PROMPT="true"
-
-# Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
-
-# Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS=true
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
-# COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# You can set one of the optional three formats:
-# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# or set a custom format using the strftime function format specifications,
-# see 'man strftime' for details.
-# HIST_STAMPS="mm/dd/yyyy"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load?
-# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
 plugins=(z)
-
 source $ZSH/oh-my-zsh.sh
 
-# User configuration
-
-# All dotfile modules are loaded here.
-# BE SURE TO SET YOUR DOTFILE PATH HERE
-export DOTFILE_DIR="/Users/taylor/repos/dotfiles/"
-# Load individual modules. Remove or add as desired.
+# ── Dotfile modules ──────────────────────────────────────────────────────────
+export DOTFILE_DIR="$HOME/repos/dotfiles/"
 source ${DOTFILE_DIR}bash/.alias
 source ${DOTFILE_DIR}bash/.exports
-source ${DOTFILE_DIR}bash/.secrets
+[ -f ${DOTFILE_DIR}bash/.secrets ] && source ${DOTFILE_DIR}bash/.secrets
 
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
-
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
+# ── Prompt ───────────────────────────────────────────────────────────────────
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
+# ── Completions ──────────────────────────────────────────────────────────────
 autoload -Uz compinit
 zstyle ':completion:*' menu select
 fpath+=~/.zfunc
 
+# ── Tool integrations ────────────────────────────────────────────────────────
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
 # Google Cloud SDK (installed via brew cask or manual install)
@@ -137,22 +36,14 @@ elif [ -f "$BREW_PREFIX/share/google-cloud-sdk/path.zsh.inc" ]; then
 fi
 
 [ -f "$HOME/.config/broot/launcher/bash/br" ] && source "$HOME/.config/broot/launcher/bash/br"
-# OpenJDK (if installed via Homebrew)
-[ -d "$BREW_PREFIX/opt/openjdk/bin" ] && export PATH="$BREW_PREFIX/opt/openjdk/bin:$PATH"
 
-export PATH="/usr/local/bin:$PATH"
-
-# cargo path
-[ -d "$HOME/.cargo/bin" ] && export PATH="$HOME/.cargo/bin:$PATH"
-
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
 
 [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
 
-
-# OpenClaw Completion
-# source "/Users/taylor/.openclaw/completions/openclaw.zsh"
-
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+# ── Extra PATH entries ───────────────────────────────────────────────────────
+[ -d "$BREW_PREFIX/opt/openjdk/bin" ] && export PATH="$BREW_PREFIX/opt/openjdk/bin:$PATH"
+[ -d "$HOME/.cargo/bin" ] && export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -133,24 +133,23 @@ if [ -f '/Users/taylor/Downloads/google-cloud-sdk/path.zsh.inc' ]; then . '/User
 # The next line enables shell command completion for gcloud.
 if [ -f '/Users/taylor/Downloads/google-cloud-sdk/completion.zsh.inc' ]; then . '/Users/taylor/Downloads/google-cloud-sdk/completion.zsh.inc'; fi
 
-source /Users/taylor/.config/broot/launcher/bash/br
-export PATH="/usr/local/opt/openjdk/bin:$PATH"
-export PATH="/usr/local/opt/node@16/bin:$PATH"
+[ -f "$HOME/.config/broot/launcher/bash/br" ] && source "$HOME/.config/broot/launcher/bash/br"
+# OpenJDK (if installed via Homebrew)
+[ -d "$BREW_PREFIX/opt/openjdk/bin" ] && export PATH="$BREW_PREFIX/opt/openjdk/bin:$PATH"
 
-export PATH="/usr/loca/bin:$PATH"
+export PATH="/usr/local/bin:$PATH"
 
 # cargo path
-export PATH="/Users/taylor/.cargo/bin:$PATH"
+[ -d "$HOME/.cargo/bin" ] && export PATH="$HOME/.cargo/bin:$PATH"
 
 
-. "$HOME/.local/bin/env"
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
 
-# Amp CLI
-# export PATH="/Users/taylor/.amp/bin:$PATH"
 
 # OpenClaw Completion
-source "/Users/taylor/.openclaw/completions/openclaw.zsh"
+# source "/Users/taylor/.openclaw/completions/openclaw.zsh"
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+export PATH="$HOME/.local/bin:$PATH"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -127,11 +127,14 @@ fpath+=~/.zfunc
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
-# The next line updates PATH for the Google Cloud SDK.
-if [ -f '/Users/taylor/Downloads/google-cloud-sdk/path.zsh.inc' ]; then . '/Users/taylor/Downloads/google-cloud-sdk/path.zsh.inc'; fi
-
-# The next line enables shell command completion for gcloud.
-if [ -f '/Users/taylor/Downloads/google-cloud-sdk/completion.zsh.inc' ]; then . '/Users/taylor/Downloads/google-cloud-sdk/completion.zsh.inc'; fi
+# Google Cloud SDK (installed via brew cask or manual install)
+if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
+  . "$HOME/google-cloud-sdk/path.zsh.inc"
+  [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ] && . "$HOME/google-cloud-sdk/completion.zsh.inc"
+elif [ -f "$BREW_PREFIX/share/google-cloud-sdk/path.zsh.inc" ]; then
+  . "$BREW_PREFIX/share/google-cloud-sdk/path.zsh.inc"
+  [ -f "$BREW_PREFIX/share/google-cloud-sdk/completion.zsh.inc" ] && . "$BREW_PREFIX/share/google-cloud-sdk/completion.zsh.inc"
+fi
 
 [ -f "$HOME/.config/broot/launcher/bash/br" ] && source "$HOME/.config/broot/launcher/bash/br"
 # OpenJDK (if installed via Homebrew)


### PR DESCRIPTION
## Summary
- **Apple Silicon support**: Add `BREW_PREFIX` detection in `.exports`, replace all hardcoded `/usr/local` paths with architecture-aware alternatives
- **Guard optional tools**: broot, cargo, `.local/bin/env`, OpenJDK, Ruby all wrapped with existence checks so shell startup doesn't error on a fresh machine
- **Remove dead code**: Travis CI function, sclack alias, Node 16 path, duplicate tailscale/fzf installs, stale gcloud `~/Downloads` path
- **Fix bugs**: `/usr/loca/bin` typo, `alias p'pulumi'` syntax error, `gh` credential helper now uses PATH lookup

## Test plan
- [ ] Run `setup.sh` on fresh Apple Silicon Mac
- [ ] Verify shell starts clean with no errors (`zsh -l` with no missing file warnings)
- [ ] Confirm `gh auth` works via gitconfig credential helper
- [ ] Confirm `brew.sh` runs without duplicate installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)