### PR TITLE
Replace brew.sh with Brewfile, fix pp alias conflict

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,142 @@
+# ── Taps ─────────────────────────────────────────────────────────────────────
+tap "romkatv/powerlevel10k"
+tap "supabase/tap"
+
+# ── Languages & runtimes ────────────────────────────────────────────────────
+brew "python"
+brew "python-tk"                          # Tk bindings for Python
+brew "uv"                                 # Fast Python package manager
+brew "bash"
+brew "bash-completion@2"
+# brew "go"
+# brew "rust"
+# brew "node"
+# brew "deno"
+
+# ── Shell ────────────────────────────────────────────────────────────────────
+brew "romkatv/powerlevel10k/powerlevel10k"
+
+# ── CLI tools ────────────────────────────────────────────────────────────────
+brew "git"
+brew "git-lfs"
+brew "git-delta"                          # Beautiful git diffs
+brew "gh"                                 # GitHub CLI
+brew "fzf"                                # Fuzzy finder (shell integration in setup.sh)
+brew "ripgrep"                            # rg — fast grep
+brew "bat"                                # cat with syntax highlighting
+brew "eza"                                # Modern ls replacement
+brew "jq"                                 # JSON processor
+brew "neovim"
+brew "tmux"
+brew "wget"
+brew "watchexec"                          # File watcher
+brew "csvkit"                             # CSV tools
+brew "s3cmd"                              # S3 command-line tool
+# brew "coreutils"                        # GNU core utilities
+# brew "htop"
+# brew "btop"
+# brew "glow"                             # Markdown renderer for terminal
+# brew "broot"                            # Interactive directory navigator
+# brew "xsv"                              # CSV tools (Rust)
+
+# ── Cloud & infrastructure ───────────────────────────────────────────────────
+brew "supabase/tap/supabase"
+# brew "awscli"
+# brew "kubernetes-cli"
+# brew "helm"
+# brew "pulumi"
+# brew "colima"
+
+# ── Databases ────────────────────────────────────────────────────────────────
+# brew "duckdb"
+# brew "redis"
+
+# ── AI / ML ──────────────────────────────────────────────────────────────────
+# brew "ollama"
+
+# ── Media ────────────────────────────────────────────────────────────────────
+# brew "ffmpeg"
+# brew "yt-dlp"
+
+# ── Dev extras ───────────────────────────────────────────────────────────────
+# brew "pipx"
+# brew "yarn"
+
+# ── Cask apps ────────────────────────────────────────────────────────────────
+
+# Terminals & editors
+cask "ghostty"
+cask "iterm2"
+cask "pulsar"
+cask "jetbrains-toolbox"
+# cask "visual-studio-code"
+# cask "cursor"
+# cask "warp"
+
+# Browsers
+cask "google-chrome"
+cask "firefox"
+# cask "arc"
+
+# Communication
+cask "slack"
+cask "microsoft-teams"
+cask "zoom"
+# cask "telegram"
+
+# Dev tools
+cask "claude"
+cask "postgres-unofficial"                # Postgres.app
+cask "tailscale"
+# cask "docker"
+# cask "tableplus"
+# cask "postman"
+# cask "ngrok"
+# cask "cyberduck"
+# cask "google-cloud-sdk"
+
+# Productivity
+cask "alfred"
+cask "deckset"                            # Markdown presentations
+# cask "obsidian"
+# cask "bear"
+# cask "joplin"
+# cask "xmind"
+# cask "loom"
+
+# Creative & media
+cask "spotify"
+cask "inkscape"
+cask "bambu-studio"                       # 3D printer slicer
+# cask "figma"
+# cask "blender"
+# cask "vlc"
+# cask "obs"
+# cask "gimp"
+# cask "openscad"
+# cask "gifox"
+# cask "gifski"
+# cask "kicad"
+# cask "lightburn"
+# cask "autodesk-fusion"
+
+# System utilities
+cask "flux"
+cask "appcleaner"
+# cask "karabiner-elements"
+# cask "caffeine"
+# cask "swish"
+# cask "sound-control"
+# cask "1blocker"
+# cask "macfuse"
+# cask "virtualbox"
+
+# Hardware & maker
+# cask "raspberry-pi-imager"
+# cask "keymapp"                          # ZSA keyboard configurator
+# cask "balenaetcher"
+# cask "qmk-toolbox"
+
+# Voice & dictation
+# cask "aqua-voice"
+# cask "wispr-flow"

--- a/bash/.alias
+++ b/bash/.alias
@@ -63,7 +63,6 @@ alias s..="source ../venv/bin/activate 2> /dev/null || source ../.venv/bin/activ
 alias s.="source venv/bin/activate 2> /dev/null || source .venv/bin/activate 2> /dev/null || echo 'Could not find your virtualenv'"
 alias cookiecutter-minimal="cookiecutter https://github.com/Aylr/cookiecutter-python-package-minimal"
 alias jpl="jupyter lab"
-alias pp="pandas_profiling"
 alias m.="mypy ."
 
 function glint () {

--- a/setup.sh
+++ b/setup.sh
@@ -80,9 +80,10 @@ fi
 
 # ── Stage 2: Packages ────────────────────────────────────────────────────────
 
-header "Stage 2: Packages (brew.sh)"
+header "Stage 2: Packages (Brewfile)"
 
-bash "$DOTFILES_DIR/brew.sh"
+info "Running brew bundle..."
+brew bundle --file="$DOTFILES_DIR/Brewfile"
 success "Packages installed."
 
 # ── Stage 3: Shell ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Brewfile**: Converts `brew.sh` to a declarative `Brewfile` used by `brew bundle`. Same packages, cleaner format. Commented-out packages serve as a menu of optional installs.
- **setup.sh**: Stage 2 now runs `brew bundle --file=Brewfile` instead of `bash brew.sh`
- **pp alias**: Removed dead `pandas_profiling` alias (package renamed to ydata-profiling) that was silently overwritten by `pulumi preview`

### Why Brewfile?
- `brew bundle install` is idempotent — skips already-installed packages
- `brew bundle cleanup` removes anything not in the Brewfile
- `brew bundle dump` can regenerate it from current installs
- No `brew update/upgrade/cleanup` boilerplate needed

Note: `brew.sh` is kept in the repo for now (not deleted) in case you want to reference it. Can delete in a follow-up.

## Test plan
- [ ] Run `brew bundle --file=Brewfile` and verify packages install
- [ ] Verify `pp` resolves to `pulumi preview` (no more conflict)
- [ ] Run full `setup.sh` on fresh machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)